### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows to use the MKR Motor Carrier
 paragraph=Allows to use the MKR Motor Carrier
-category=I/o
+category=Signal Input/Output
 url=http://www.arduino.cc/en/Reference/
 architectures=samd


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'I/o' in library MKRMotorCarrier is not valid. Setting to 'Uncategorized'
```