### PR TITLE
Use single tab keywords.txt field separator

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -45,7 +45,7 @@ setGains	KEYWORD2
 resetGains	KEYWORD2
 setControlMode	KEYWORD2
 setSetpoint	KEYWORD2
-setMaxAcceleration		KEYWORD2
+setMaxAcceleration	KEYWORD2
 setMaxVelocity	KEYWORD2
 setLimits	KEYWORD2
 setAngle	KEYWORD2


### PR DESCRIPTION
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords