### PR TITLE
Add includes field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Allows to use the Arduino Motor shields
 category=Signal Input/Output
 url=http://www.arduino.cc/en/Reference/
 architectures=samd
+includes=ArduinoMotorCarrier.h


### PR DESCRIPTION
Previously, **Sketch > Include Library > ArduinoMotorCarrier** would add `#include` directives for all the .h files under `src` to the sketch:
```c++
#include <ArduinoMotorCarrier.h>
#include <Battery.h>
#include <Common.h>
#include <DCMotor.h>
#include <Encoder.h>
#include <MKRMotorCarrier.h>
#include <MotorController.h>
#include <NanoMotorCarrier.h>
#include <PID.h>
#include <ServoMotor.h>
```
resulting in redefinition errors.

Setting the `includes` field of library.properties to `ArduinoMotorCarrier.h` results in **Sketch > Include Library > ArduinoMotorCarrier** only adding an `#include` directive for that file.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format